### PR TITLE
Added a semicolon at the end of config.js...

### DIFF
--- a/js/bl/customgrid/config.js
+++ b/js/bl/customgrid/config.js
@@ -2074,4 +2074,4 @@ blcg.Filter.Categories.prototype = {
             blcg.Tools.closeDialog(this.window);
         }
     }
-}
+};


### PR DESCRIPTION
.. to prevent breakages due to the Magento JS minify function.

If a Javascript file from another extension is in line behind this extensions' config.js and the minify function in the backend is enabled, the Javascript will throw errors and break functionality. Placing a semicolon at the end of the file fixes this.
