### PR TITLE
Transparent button styles

### DIFF
--- a/skin/adminhtml/default/default/bl/customgrid/styles.css
+++ b/skin/adminhtml/default/default/bl/customgrid/styles.css
@@ -87,7 +87,7 @@ div.blcg-collapseable a.open { background:url(images/collapse_arrow_up.png) 100%
     padding:2px 6px 2px;
     background:none;
     border:none;
-    color: #ccc;
+    color: #ddd;
 }
 .blcg-grid-profiles-bar-button:hover {
     background:none;


### PR DESCRIPTION
New concept, what do you think? (When you hover over the icons they become black, thus more visible).

![schermafbeelding 2014-11-06 om 21 36 10](https://cloud.githubusercontent.com/assets/1244416/4943453/965c5e64-65f4-11e4-9d02-a035ea2708ab.png)

The reason I want to remove as much chrome (not the browser) as possible is because I believe the tool (the grid editor) works best when it's there when you need it, but isn't the primary focus when you're not using it.

Ps. If I have more idea's, I'll let you know.
