### PR TITLE
Make composer definition compatible with advised version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "magento-module",
     "description": "Enhanced Admin Grids Extension for Magento",
     "require": {
-        "magento-hackathon/magento-composer-installer": "dev-master"
+        "magento-hackathon/magento-composer-installer": "*"
     }
 }
 


### PR DESCRIPTION
The `mage-composer-installer` advises to install their composer plugin with `*` instead of `dev-master`. This will fix compatibility installing.