### PR TITLE
Fix issue with upgrade script 1.0.0-1.0.0.1

### DIFF
--- a/app/code/community/BL/CustomGrid/sql/customgrid_setup/mysql4-upgrade-1.0.0-1.0.0.1.php
+++ b/app/code/community/BL/CustomGrid/sql/customgrid_setup/mysql4-upgrade-1.0.0-1.0.0.1.php
@@ -36,7 +36,7 @@ $tables = array(
 $connection->addColumn(
     $tables['grid'],
     'base_profile_id',
-    'int(10) default NULL'
+    'int(10) unsigned default NULL'
 );
 
 $connection->addConstraint(
@@ -51,7 +51,7 @@ $connection->addConstraint(
 $connection->addColumn(
     $tables['grid'],
     'global_default_profile_id',
-    'int(10) default NULL'
+    'int(10) unsigned default NULL'
 );
 
 $connection->addConstraint(


### PR DESCRIPTION
Columns were being created without the unsigned attribute.
The script would then try to assign foreign keys to other tables with
unsigned attributes, causing an SQL errno: 150.