### PR TITLE
Grid usability enhancements

### DIFF
--- a/app/code/community/BL/CustomGrid/Model/Custom/Column/Abstract.php
+++ b/app/code/community/BL/CustomGrid/Model/Custom/Column/Abstract.php
@@ -20,8 +20,8 @@
  * @method this setAllowCustomization(bool $flag) Set whether this columns is customizable
  * @method this setAllowRenderers(bool $flag) Set whether this column allows to choose a renderer
  * @method this setAllowStore(bool $flag) Set whether this column allows to choose a base store view
+ * @method BL_CustomGrid_Model_Custom_Column_Abstract setCurrentBlockValues(array $currentBlockValues)
  */
-
 abstract class BL_CustomGrid_Model_Custom_Column_Abstract extends BL_CustomGrid_Object
 {
     /**

--- a/app/code/community/BL/CustomGrid/Model/Custom/Column/Action.php
+++ b/app/code/community/BL/CustomGrid/Model/Custom/Column/Action.php
@@ -1,0 +1,63 @@
+<?php
+
+class BL_CustomGrid_Model_Custom_Column_Action extends BL_CustomGrid_Model_Custom_Column_Abstract
+{
+    /**
+     * @var string
+     */
+    protected $_getter = "getId";
+
+    /**
+     * @var string
+     */
+    protected $_field = "id";
+
+    /**
+     * Apply the custom column to the given grid collection
+     *
+     * @param Varien_Data_Collection_Db $collection
+     * @param Mage_Adminhtml_Block_Widget_Grid $gridBlock
+     * @param BL_CustomGrid_Model_Grid $gridModel
+     * @param string $columnBlockId
+     * @param string $columnIndex
+     * @param array $params
+     * @param Mage_Core_Model_Store $store
+     * @return $this
+     */
+    public function applyToGridCollection(
+        Varien_Data_Collection_Db $collection,
+        Mage_Adminhtml_Block_Widget_Grid $gridBlock,
+        BL_CustomGrid_Model_Grid $gridModel,
+        $columnBlockId,
+        $columnIndex,
+        array $params,
+        Mage_Core_Model_Store $store
+    ) {
+        return $this;
+    }
+
+    public function getForcedBlockValues(
+        Mage_Adminhtml_Block_Widget_Grid $gridBlock,
+        BL_CustomGrid_Model_Grid $gridModel,
+        $customBlockId,
+        $columnIndex,
+        array $params,
+        Mage_Core_Model_Store $store
+    ) {
+        $values = array(
+            "type"      => "action",
+            "filter"    => false,
+            "sortable"  => false,
+            "is_system" => true,
+        );
+
+        $editSettings = $this->getCurrentBlockValues();
+        if (isset($editSettings["actions"])) {
+            $values["actions"] = $editSettings["actions"];
+            $values["actions"]["edit"]["caption"] = "Edit";
+            $values["actions"]["edit"]["url"] = array("base" => "*/*/edit");
+        }
+
+        return $values;
+    }
+}

--- a/app/code/community/BL/CustomGrid/Model/Grid/Type/Product/Attributes.php
+++ b/app/code/community/BL/CustomGrid/Model/Grid/Type/Product/Attributes.php
@@ -1,0 +1,14 @@
+<?php
+
+class BL_CustomGrid_Model_Grid_Type_Product_Attributes extends BL_CustomGrid_Model_Grid_Type_Abstract
+{
+    /**
+     * @return string[]|string
+     */
+    protected function _getSupportedBlockTypes()
+    {
+        return array(
+            'adminhtml/catalog_product_attribute_grid',
+        );
+    }
+}

--- a/app/code/community/BL/CustomGrid/Model/Grid/Type/Product/Rating.php
+++ b/app/code/community/BL/CustomGrid/Model/Grid/Type/Product/Rating.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   BL
+ * @package    BL_CustomGrid
+ * @copyright  Copyright (c) 2014 Benoît Leulliette <benoit.leulliette@gmail.com>
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+class BL_CustomGrid_Model_Grid_Type_Product_Rating extends BL_CustomGrid_Model_Grid_Type_Abstract
+{
+    /**
+     * @return string[]|string
+     */
+    protected function _getSupportedBlockTypes()
+    {
+        return array('adminhtml/rating_grid');
+    }
+
+    /**
+     * @param string $blockType
+     * @return array
+     */
+    protected function _getBaseEditableFields($blockType)
+    {
+        $fields = array(
+            'rating_code' => array(
+                'type'     => 'text',
+                'required' => true,
+            ),
+            'position' => array(
+                'type'       => 'text',
+                'required'   => true,
+                'form_class' => 'validate-number',
+            ),
+        );
+
+        return $fields;
+    }
+
+    protected function _getEntityRowIdentifiersKeys($blockType)
+    {
+        return array('rating_id');
+    }
+
+    protected function _loadEditedEntity($blockType, BL_CustomGrid_Object $config, array $params, $entityId)
+    {
+        return Mage::getModel('rating/rating')->load($entityId);
+    }
+
+    protected function _getEditRequiredAclPermissions($blockType)
+    {
+        return 'catalog/reviews_ratings/ratings';
+    }
+}

--- a/app/code/community/BL/CustomGrid/etc/customgrid.xml
+++ b/app/code/community/BL/CustomGrid/etc/customgrid.xml
@@ -348,6 +348,29 @@
             <name>Reviews</name>
             <sort_order>180000</sort_order>
         </product_review>
+
+        <product_rating model="customgrid/grid_type_product_rating" module="customgrid">
+            <name>Review Ratings</name>
+            <sort_order>181000</sort_order>
+            <custom_columns>
+                <action model="customgrid/custom_column_action" module="customgrid">
+                    <name>Action</name>
+                    <group>Misc</group>
+                    <allow_customization>0</allow_customization>
+                    <config_params>
+                        <is_use_config_field>1</is_use_config_field>
+                    </config_params>
+                    <block_params>
+                        <getter>getId</getter>
+                        <actions>
+                            <edit>
+                                <field>id</field>
+                            </edit>
+                        </actions>
+                    </block_params>
+                </action>
+            </custom_columns>
+        </product_rating>
         
         <sitemap model="customgrid/grid_type_sitemap" module="customgrid">
             <name>Google Sitemap</name>

--- a/app/code/community/BL/CustomGrid/etc/customgrid.xml
+++ b/app/code/community/BL/CustomGrid/etc/customgrid.xml
@@ -24,6 +24,24 @@
         <cms_block model="customgrid/grid_type_cms_block" module="customgrid">
             <name>CMS Blocks</name>
             <sort_order>20000</sort_order>
+            <custom_columns>
+                <action model="customgrid/custom_column_action" module="customgrid">
+                    <name>Action</name>
+                    <group>Misc</group>
+                    <allow_customization>0</allow_customization>
+                    <config_params>
+                        <is_use_config_field>1</is_use_config_field>
+                    </config_params>
+                    <block_params>
+                        <getter>getId</getter>
+                        <actions>
+                            <edit>
+                                <field>block_id</field>
+                            </edit>
+                        </actions>
+                    </block_params>
+                </action>
+            </custom_columns>
         </cms_block>
         
         <cms_page model="customgrid/grid_type_cms_page" module="customgrid">
@@ -247,6 +265,29 @@
                 </stock_is_in_stock>
             </custom_columns>
         </product>
+
+        <product_attribute model="customgrid/grid_type_product_attributes" module="customgrid">
+            <name>Product Attributes</name>
+            <sort_order>65000</sort_order>
+            <custom_columns>
+                <action model="customgrid/custom_column_action" module="customgrid">
+                    <name>Action</name>
+                    <group>Misc</group>
+                    <allow_customization>0</allow_customization>
+                    <config_params>
+                        <is_use_config_field>1</is_use_config_field>
+                    </config_params>
+                    <block_params>
+                        <getter>getId</getter>
+                        <actions>
+                            <edit>
+                                <field>attribute_id</field>
+                            </edit>
+                        </actions>
+                    </block_params>
+                </action>
+            </custom_columns>
+        </product_attribute>
         
         <customer model="customgrid/grid_type_customer" module="customgrid">
             <name>Customers</name>


### PR DESCRIPTION
Several grids within Magento lack action columns by default. This can be annoying, as it's often desirable to open several CMS blocks at once in different tabs, for example.

This pull request adds support for action columns through the custom columns system on the CMS Blocks, Product Review Ratings and Product Attributes grids. It also adds the ability to edit position values for review ratings in the Product Review Ratings grid.

To achieve this, a small but significant change has been made to the way configuration is loaded for custom columns. In order to make this as flexible as possible, nested elements are supported in the configuration. This meant using `array_replace_recursive()` for all of the configuration for a custom column. `array_replace_recursive()` was chosen over `array_merge_recursive()` as the latter will combine two string values into an array when they have the same key, rather than having the second value overwrite the first value. This is counter-intuitive to what Magento developers would expect after having used Magento's own config system extensively. `array_replace_recursive()` does behave as expected in this instance.