### PR TITLE
Make grid model type loading respect sort orders

### DIFF
--- a/app/code/community/BL/CustomGrid/Model/Config/Abstract.php
+++ b/app/code/community/BL/CustomGrid/Model/Config/Abstract.php
@@ -98,10 +98,16 @@ abstract class BL_CustomGrid_Model_Config_Abstract extends BL_CustomGrid_Object
             $codes = array();
             
             foreach ($this->getRootXmlElement()->children() as $xmlElement) {
-                $codes[] = $xmlElement->getName();
+                $codes[(int) $xmlElement->descend("sort_order")][] = $xmlElement->getName();
+            }
+            ksort($codes, SORT_NUMERIC);
+
+            $sortedCodes = array();
+            foreach ($codes as $codeGroup) {
+                $sortedCodes = array_merge($sortedCodes, array_values($codeGroup));
             }
             
-            $this->setData('elements_codes', $codes);
+            $this->setData('elements_codes', $sortedCodes);
         }
         return $this->_getData('elements_codes');
     }


### PR DESCRIPTION
Previously, grid types defined by third-party extensions whose config
was loaded after this extensoin's config would not work, because the
"other" grid type would match first. This change ensures that sort
orders are respected, thereby allowing other extensions to reliably
create their own grid types.