### PR TITLE
Fix bug with exporting collections on any grid in older Magento versions

### DIFF
--- a/app/code/community/BL/CustomGrid/controllers/GridController.php
+++ b/app/code/community/BL/CustomGrid/controllers/GridController.php
@@ -288,12 +288,12 @@ class BL_CustomGrid_GridController extends BL_CustomGrid_Controller_Grid_Action
             $this->_prepareDownloadResponse($fileName, $exportOutput);
         } catch (Mage_Core_Exception $e) {
             $this->_getSession()->addError($e->getMessage());
+            $this->_redirectReferer();
         } catch (Exception $e) {
             Mage::logException($e);
             $this->_getSession()->addError($this->__('An error occured while exporting grid results'));
-            
+            $this->_redirectReferer();
         }
-        $this->_redirectReferer();
     }
     
     public function exportCsvAction()


### PR DESCRIPTION
In newer Magento versions the `_prepareDownloadResponse` method exits
immediately, which means it's safe to place the `redirectReferer()` call
outside of the catch blocks. In older versions, it doesn't exit
immediately, which means the redirect always blows away the download
response headers. By moving the redirect calls into the catch blocks, it
will never be called when exceptions don't occur.