### PR TITLE
Add new column renderer for CSV fields

### DIFF
--- a/app/code/community/BL/CustomGrid/Block/Widget/Grid/Column/Renderer/Csv.php
+++ b/app/code/community/BL/CustomGrid/Block/Widget/Grid/Column/Renderer/Csv.php
@@ -1,0 +1,17 @@
+<?php
+
+class BL_CustomGrid_Block_Widget_Grid_Column_Renderer_Csv extends Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Abstract
+{
+    public function render(Varien_Object $row)
+    {
+        // pretty up the CSV for human consumption
+        $value = parent::_getValue($row);
+        $values = explode(",", $value);
+        return implode(", ", $values);
+    }
+
+    public function renderExport(Varien_Object $row)
+    {
+        return parent::_getValue($row);
+    }
+}


### PR DESCRIPTION
This renderer is designed for text output that is already
comma-separated. Its only function is to prettify the output when
displayed in the grid (as opposed to being displayed in an export).

This is used by some of our internal code, not in the extension itself.
Happy to clean it up or change the name to something else.