### PR TITLE
Fix incompatibilities with Magento 1.6CE+/1.11EE+

### DIFF
--- a/app/code/community/BL/CustomGrid/Block/Widget/Grid/Column/Renderer/Product/Categories.php
+++ b/app/code/community/BL/CustomGrid/Block/Widget/Grid/Column/Renderer/Product/Categories.php
@@ -17,7 +17,7 @@ class BL_CustomGrid_Block_Widget_Grid_Column_Renderer_Product_Categories extends
     Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Text
 {
     protected function _getCategoryTreeResult(
-        Mage_Catalog_Model_Resource_Eav_Mysql4_Category_Tree $tree,
+        $tree,
         array $categoryIds,
         $displayIds,
         $minimumLevel

--- a/app/code/community/BL/CustomGrid/Model/Grid/Type/Product.php
+++ b/app/code/community/BL/CustomGrid/Model/Grid/Type/Product.php
@@ -466,7 +466,8 @@ class BL_CustomGrid_Model_Grid_Type_Product extends BL_CustomGrid_Model_Grid_Typ
         Mage_Adminhtml_Block_Widget_Grid $gridBlock, 
         Varien_Data_Collection $collection
     ) {
-        if ($collection instanceof Mage_Catalog_Model_Resource_Eav_Mysql4_Product_Collection) {
+        if ($collection instanceof Mage_Catalog_Model_Resource_Eav_Mysql4_Product_Collection ||
+            $collection instanceof Mage_Catalog_Model_Resource_Product_Collection) {
             $collection->addWebsiteNamesToResult();
         }
         return $this;


### PR DESCRIPTION
There are two places where checks are made against the old Eav_Mysql4
classes in catalog-related code. One of these is an instanceof check
that can easily be expanded to include the new Resource classes. The
other is a strict type-hint in a method signature. This type-hint
has been removed.