### PR TITLE
Fix bug with incorrect number of columns in columns list grids

### DIFF
--- a/app/design/adminhtml/default/default/template/bl/customgrid/widget/grid/config/columns/list.phtml
+++ b/app/design/adminhtml/default/default/template/bl/customgrid/widget/grid/config/columns/list.phtml
@@ -91,7 +91,7 @@
                         <?php if ($this->canDisplayEditablePart()): ?>
                             <th><span class="nobr"><?php echo $this->__('Editable') ?></span></th>
                         <?php endif ?>
-                        <?php if ($this->canDisplayStorePart()): ?>
+                        <?php if ($this->canDisplaySystemPart()): ?>
                             <th><span class="nobr"><?php echo $this->__('System') ?></span></th>
                         <?php endif ?>
                         <th><span class="nobr"><?php echo $this->__('Origin') ?></span></th>


### PR DESCRIPTION
The column heading for "system" was always being displayed because the
wrong check was being performed, despite the correct check being
performed elsewhere. This fixes that issue.