### PR TITLE
Add source models for payment methods and shipping methods

### DIFF
--- a/app/code/community/BL/CustomGrid/Model/System/Config/Source/Payment/Allmethods.php
+++ b/app/code/community/BL/CustomGrid/Model/System/Config/Source/Payment/Allmethods.php
@@ -1,0 +1,12 @@
+<?php
+
+class BL_CustomGrid_Model_System_Config_Source_Payment_Allmethods
+{
+    /**
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        return Mage::helper('payment')->getPaymentMethodList(true, true);
+    }
+}

--- a/app/code/community/BL/CustomGrid/Model/System/Config/Source/Shipping/Methods.php
+++ b/app/code/community/BL/CustomGrid/Model/System/Config/Source/Shipping/Methods.php
@@ -1,0 +1,34 @@
+<?php
+
+class BL_CustomGrid_Model_System_Config_Source_Shipping_Methods
+{
+    /**
+     * Designed for use in the Sales Order grid.
+     *
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        /** @var $res Mage_Core_Model_Resource */
+        $res = Mage::getSingleton('core/resource');
+        $conn = $res->getConnection(Mage_Core_Model_Resource::DEFAULT_READ_RESOURCE);
+
+        $select = $conn->select();
+        $select->from($res->getTableName("sales/order"), array("shipping_method"));
+        $select->distinct(true);
+
+        $methods = $conn->fetchCol($select);
+
+        $return = array();
+        foreach ($methods as $method) {
+            // There isn't a sensible way to get a generic label for a method, as it can differ for each order.
+            // As a result, just use the method code as the label as well.
+            $return[] = array(
+                "value" => $method,
+                "label" => $method,
+            );
+        }
+
+        return $return;
+    }
+}


### PR DESCRIPTION
Similar to #174, these aren't actually used by anything by default. They can be set up as option sources in the extension and used by the payment method and shipping method custom columns on the sales order grid.