### PR TITLE
Fix for Delimiter must not be alphanumeric or backslash when running …

### DIFF
--- a/app/code/community/BL/CustomGrid/Helper/Config.php
+++ b/app/code/community/BL/CustomGrid/Helper/Config.php
@@ -73,8 +73,8 @@ class BL_CustomGrid_Helper_Config extends Mage_Core_Helper_Abstract
     
     protected function _matchGridAgainstException($exception, $blockType, $rewritingClassName)
     {
-        return (preg_match($exception['block_type'], $blockType)
-            && preg_match($exception['rewriting_class_name'], $rewritingClassName));
+        return (strpos($exception['block_type'], $blockType)
+            && strpos($exception['rewriting_class_name'], $rewritingClassName));
     }
     
     public function addGridToExclusionsList($blockType, $rewritingClassName, $reinit=false)


### PR DESCRIPTION
…Mage on hhvm

I am running Magento 1.8.1.0 CE on HipHop VM 3.11.0 (rel) and I get the following error on a grid running a custom grid. This change fixes the error

``` bash
Warning: Delimiter must not be alphanumeric or backslash  in /var/www/dev.site.local/releases/2016/app/code/community/BL/CustomGrid/Helper/Config.php on line 76

#0 /var/www/dev.site.local/releases/2016/app/code/community/BL/CustomGrid/Helper/Config.php(76): mageCoreErrorHandler()
#1 /var/www/dev.site.local/releases/2016/app/code/community/BL/CustomGrid/Helper/Config.php(134): BL_CustomGrid_Helper_Config->_matchGridAgainstException()
#2 /var/www/dev.site.local/releases/2016/app/code/community/BL/CustomGrid/Model/Observer.php(213): BL_CustomGrid_Helper_Config->isExcludedGrid()
#3 /var/www/dev.site.local/releases/2016/app/code/community/BL/CustomGrid/Model/Observer.php(347): BL_CustomGrid_Model_Observer->_rewriteGridBlock()
#4 /var/www/dev.site.local/releases/2016/app/code/core/Mage/Core/Model/App.php(1338): BL_CustomGrid_Model_Observer->onControllerActionPreDispatch()
#5 /var/www/dev.site.local/releases/2016/app/code/core/Mage/Core/Model/App.php(1317): Mage_Core_Model_App->_callObserverMethod()
#6 /var/www/dev.site.local/releases/2016/app/Mage.php(448): Mage_Core_Model_App->dispatchEvent()
#7 /var/www/dev.site.local/releases/2016/app/code/core/Mage/Core/Controller/Varien/Action.php(527): Mage::dispatchEvent()
#8 /var/www/dev.site.local/releases/2016/app/code/core/Mage/Adminhtml/Controller/Action.php(160): Mage_Core_Controller_Varien_Action->preDispatch()
#9 /var/www/dev.site.local/releases/2016/app/code/core/Mage/Core/Controller/Varien/Action.php(407): Mage_Adminhtml_Controller_Action->preDispatch()
#10 /var/www/dev.site.local/releases/2016/app/code/core/Mage/Core/Controller/Varien/Router/Standard.php(254): Mage_Core_Controller_Varien_Action->dispatch()
#11 /var/www/dev.site.local/releases/2016/app/code/core/Mage/Core/Controller/Varien/Front.php(172): Mage_Core_Controller_Varien_Router_Standard->match()
#12 /var/www/dev.site.local/releases/2016/app/code/core/Mage/Core/Model/App.php(354): Mage_Core_Controller_Varien_Front->dispatch()
#13 /var/www/dev.site.local/releases/2016/app/Mage.php(684): Mage_Core_Model_App->run()
#14 /var/www/dev.site.local/releases/2016/index.php(90): Mage::run()
#15 {main}
```
