### PR TITLE
Fixed  Notice: Array to string conversion  in lib/Zend/Db/Statement/P…

### DIFF
--- a/app/code/community/BL/CustomGrid/Model/Grid/Absorber.php
+++ b/app/code/community/BL/CustomGrid/Model/Grid/Absorber.php
@@ -373,6 +373,13 @@ class BL_CustomGrid_Model_Grid_Absorber extends BL_CustomGrid_Model_Grid_Worker_
         $checkedCollection = $this->_checkCollectionColumnsAgainstGridBlock($gridBlock);
         $this->_checkAttributeColumnsValidity();
         $this->_checkCustomColumnsValidity();
+       
+        foreach ($this->getGridModel()->getColumns() as $column){
+            if(is_array($column->getIndex())){
+                $column->setIndex(implode(',',$column->getIndex()));
+            }
+        }
+        
         $this->getGridModel()->setDataChanges(true)->save();
         return $checkedCollection;
     }


### PR DESCRIPTION
…do.php on line 229

If the function addColumn of adding columns in the grid.  Contains parameter 'index; as an array, there is a notice error. 
Example: 
 $this->addColumn('name', array( 
       'header' => $this->__('Customer Name'), 
       'index' => array('firstname', 'lastname'),
       'type' => 'concat', 'separator' => ' ',
       'filter_index' => new Zend_Db_Expr("CONCAT(firstname, ' ', lastname)"), 
) );
