### PR TITLE
Fixed Notice: Array to string conversion

### DIFF
--- a/app/code/community/BL/CustomGrid/Model/Grid/Absorber.php
+++ b/app/code/community/BL/CustomGrid/Model/Grid/Absorber.php
@@ -352,6 +352,13 @@ class BL_CustomGrid_Model_Grid_Absorber extends BL_CustomGrid_Model_Grid_Worker
         $checkedCollection = $this->_checkCollectionColumnsAgainstGridBlock($gridBlock);
         $this->_checkAttributeColumnsValidity();
         $this->_checkCustomColumnsValidity();
+        
+        foreach ($this->getGridModel()->getColumns() as $column){
+            if(is_array($column->getIndex())){
+                $column->setIndex(implode(',',$column->getIndex()));
+            }
+        }
+        
         $this->getGridModel()->setDataChanges(true)->save();
         return $checkedCollection;
     }


### PR DESCRIPTION
If  array key 'index' contains array('firstname', 'lastname')
function  $this->addColumn(.., 'index' => array('firstname', 'lastname'), 'type' => 'concat', 'separator' => ' ',.. ) );
