### PR TITLE
[1.0.0-wip] #287. fix issue of loading collection twice

### DIFF
--- a/app/code/community/BL/CustomGrid/Model/Grid/Type/Product.php
+++ b/app/code/community/BL/CustomGrid/Model/Grid/Type/Product.php
@@ -496,8 +496,7 @@ class BL_CustomGrid_Model_Grid_Type_Product extends BL_CustomGrid_Model_Grid_Typ
         Varien_Data_Collection $collection
     ) {
         if ($this->getMustCaptureExportedCollection()) {
-            $clonedCollection = clone $collection;
-            $gridBlock->blcg_setExportedCollection($clonedCollection);
+            $gridBlock->blcg_setExportedCollection($collection);
         }
         return $this;
     }


### PR DESCRIPTION
This fix the issue #268 with observers that creates left join to a collection.

I am not sure of this changes since I am not familiar with the module and its complexity. But this updates works for us based of what we needed.
